### PR TITLE
This fixes the app in firefox & firefox mobile

### DIFF
--- a/app/views/location-map.js
+++ b/app/views/location-map.js
@@ -1,5 +1,4 @@
 var markerLayer = EmberLeaflet.MarkerLayer.extend(EmberLeaflet.DraggableMixin, EmberLeaflet.PopupMixin, {
-  // events: ['click'],
   dragend: function() {
   }
 });
@@ -22,6 +21,7 @@ var marker = EmberLeaflet.MarkerCollectionLayer.extend({
 });
 
 export default EmberLeaflet.MapView.extend({
+  center: L.latLng(51.507351, -0.127758),
   zoom: 15,
   options: {
     maxZoom: 19, minZoom: 0
@@ -29,13 +29,13 @@ export default EmberLeaflet.MapView.extend({
 
   childLayers: [EmberLeaflet.DefaultTileLayer, marker],
 
-  center: function() {
-    window.mec = this;
-    return L.latLng(
+  updateCenter: function(){
+    var center = L.latLng(
       this.get('controller.geolocator.latitude'),
       this.get('controller.geolocator.longitude')
     );
-  }.property('controller.geolocator.latitude', 'controller.geolocator.longitude'),
+    this.set('center', Center);
+  }.observes('controller.geolocator.latitude', 'controller.geolocator.longitude'),
 
   events: ['click'],
 });

--- a/app/views/products/map.js
+++ b/app/views/products/map.js
@@ -1,5 +1,3 @@
-// import Ember from "ember";
-
 var marker = EmberLeaflet.MarkerCollectionLayer.extend({
   content: function() {
     var lat = this.get('controller.latitude');


### PR DESCRIPTION
Apparently EmberLeafleet crashes if the center is not defined by the time the view is initialized, and in firefox the geolocation works in an asynchronous fashion.

Now the center is initialized to an arbitrary position, and updated with an observer (it used to be a computed property)
